### PR TITLE
Fix extra `}` generated when `ret ++ fargs` is empty

### DIFF
--- a/vc/src/Main.hs
+++ b/vc/src/Main.hs
@@ -259,7 +259,7 @@ fillInFunction topLevelContract file imports (FuncDef _ contract fargs ret body)
         funcArgs     = generateGuarded (null fargs) $ "(" ++ unwords fargs ++ " : Literal)"
         opens        = opensOfImports topLevelContract imports
         retVals      = generateGuarded (null ret) $ "(" ++ unwords ret ++ " : Identifier)"
-        rValsAndArgs = generateGuarded (null (ret ++ fargs)) "{" ++ unwords ret ++ " " ++ argsSepSpace ++ "}"
+        rValsAndArgs = generateGuarded (null (ret ++ fargs)) $ "{" ++ unwords ret ++ " " ++ argsSepSpace ++ "}"
         replaceIn ttype =
           replaceMany [
             ("\\<imports>",                       leanImports ++ internalImports topLevelContract contract file ttype),


### PR DESCRIPTION
Add missing `$` so that the use of `generateGuarded` behaves correctly.

This fixes, for example, in the `erc20` branch currently in `Generated/erc20shim/ERC20Shim/panic_error_0x11_user.lean` we have: `lemma panic_error_0x11_abs_of_concrete {s₀ s₉ : State}  } :` on [line 15](https://github.com/NethermindEth/Clear/blob/e4c21655f140889ced82b3bb6653aff2ef016dad/Generated/erc20shim/ERC20Shim/panic_error_0x11_user.lean#L15C1-L15C60).

For other occurrences of this bug, `grep -r "}  }"` in the [erc20 branch - currently (e4c216)](https://github.com/NethermindEth/Clear/tree/e4c21655f140889ced82b3bb6653aff2ef016dad).