### PR TITLE
Fix extra `}` generated when `ret ++ fargs` is empty and remove extra `}`s from generated files

### DIFF
--- a/Generated/erc20shim/ERC20Shim/panic_error_0x11.lean
+++ b/Generated/erc20shim/ERC20Shim/panic_error_0x11.lean
@@ -12,7 +12,7 @@ section
 
 open Clear EVMState Ast Expr Stmt FunctionDefinition State Interpreter ExecLemmas OutOfFuelLemmas Abstraction YulNotation PrimOps ReasoningPrinciple Utilities 
 
-lemma panic_error_0x11_abs_of_code {s₀ s₉ : State}  } {fuel : Nat} :
+lemma panic_error_0x11_abs_of_code {s₀ s₉ : State}  {fuel : Nat} :
   execCall fuel panic_error_0x11 [] (s₀, []) = s₉ →
   Spec (A_panic_error_0x11  ) s₀ s₉
 := λ h ↦ panic_error_0x11_abs_of_concrete (panic_error_0x11_concrete_of_code.2 h)

--- a/Generated/erc20shim/ERC20Shim/panic_error_0x11_user.lean
+++ b/Generated/erc20shim/ERC20Shim/panic_error_0x11_user.lean
@@ -12,7 +12,7 @@ open Clear EVMState Ast Expr Stmt FunctionDefinition State Interpreter ExecLemma
 
 def A_panic_error_0x11   (s₀ s₉ : State) : Prop := sorry
 
-lemma panic_error_0x11_abs_of_concrete {s₀ s₉ : State}  } :
+lemma panic_error_0x11_abs_of_concrete {s₀ s₉ : State}  :
   Spec (panic_error_0x11_concrete_of_code.1  ) s₀ s₉ →
   Spec (A_panic_error_0x11  ) s₀ s₉ := by
   unfold panic_error_0x11_concrete_of_code A_panic_error_0x11

--- a/Generated/erc20shim/ERC20Shim/panic_error_0x22.lean
+++ b/Generated/erc20shim/ERC20Shim/panic_error_0x22.lean
@@ -12,7 +12,7 @@ section
 
 open Clear EVMState Ast Expr Stmt FunctionDefinition State Interpreter ExecLemmas OutOfFuelLemmas Abstraction YulNotation PrimOps ReasoningPrinciple Utilities 
 
-lemma panic_error_0x22_abs_of_code {s₀ s₉ : State}  } {fuel : Nat} :
+lemma panic_error_0x22_abs_of_code {s₀ s₉ : State}  {fuel : Nat} :
   execCall fuel panic_error_0x22 [] (s₀, []) = s₉ →
   Spec (A_panic_error_0x22  ) s₀ s₉
 := λ h ↦ panic_error_0x22_abs_of_concrete (panic_error_0x22_concrete_of_code.2 h)

--- a/Generated/erc20shim/ERC20Shim/panic_error_0x22_user.lean
+++ b/Generated/erc20shim/ERC20Shim/panic_error_0x22_user.lean
@@ -12,7 +12,7 @@ open Clear EVMState Ast Expr Stmt FunctionDefinition State Interpreter ExecLemma
 
 def A_panic_error_0x22   (s₀ s₉ : State) : Prop := sorry
 
-lemma panic_error_0x22_abs_of_concrete {s₀ s₉ : State}  } :
+lemma panic_error_0x22_abs_of_concrete {s₀ s₉ : State}  :
   Spec (panic_error_0x22_concrete_of_code.1  ) s₀ s₉ →
   Spec (A_panic_error_0x22  ) s₀ s₉ := by
   unfold panic_error_0x22_concrete_of_code A_panic_error_0x22

--- a/Generated/erc20shim/ERC20Shim/panic_error_0x41.lean
+++ b/Generated/erc20shim/ERC20Shim/panic_error_0x41.lean
@@ -12,7 +12,7 @@ section
 
 open Clear EVMState Ast Expr Stmt FunctionDefinition State Interpreter ExecLemmas OutOfFuelLemmas Abstraction YulNotation PrimOps ReasoningPrinciple Utilities 
 
-lemma panic_error_0x41_abs_of_code {s₀ s₉ : State}  } {fuel : Nat} :
+lemma panic_error_0x41_abs_of_code {s₀ s₉ : State}  {fuel : Nat} :
   execCall fuel panic_error_0x41 [] (s₀, []) = s₉ →
   Spec (A_panic_error_0x41  ) s₀ s₉
 := λ h ↦ panic_error_0x41_abs_of_concrete (panic_error_0x41_concrete_of_code.2 h)

--- a/Generated/erc20shim/ERC20Shim/panic_error_0x41_user.lean
+++ b/Generated/erc20shim/ERC20Shim/panic_error_0x41_user.lean
@@ -12,7 +12,7 @@ open Clear EVMState Ast Expr Stmt FunctionDefinition State Interpreter ExecLemma
 
 def A_panic_error_0x41   (s₀ s₉ : State) : Prop := sorry
 
-lemma panic_error_0x41_abs_of_concrete {s₀ s₉ : State}  } :
+lemma panic_error_0x41_abs_of_concrete {s₀ s₉ : State}  :
   Spec (panic_error_0x41_concrete_of_code.1  ) s₀ s₉ →
   Spec (A_panic_error_0x41  ) s₀ s₉ := by
   unfold panic_error_0x41_concrete_of_code A_panic_error_0x41

--- a/Generated/erc20shim/ERC20Shim/revert_error_42b3090547df1d2001c96683413b8cf91c1b902ef5e3cb8d9f6f304cf7446f74.lean
+++ b/Generated/erc20shim/ERC20Shim/revert_error_42b3090547df1d2001c96683413b8cf91c1b902ef5e3cb8d9f6f304cf7446f74.lean
@@ -12,7 +12,7 @@ section
 
 open Clear EVMState Ast Expr Stmt FunctionDefinition State Interpreter ExecLemmas OutOfFuelLemmas Abstraction YulNotation PrimOps ReasoningPrinciple Utilities 
 
-lemma revert_error_42b3090547df1d2001c96683413b8cf91c1b902ef5e3cb8d9f6f304cf7446f74_abs_of_code {s₀ s₉ : State}  } {fuel : Nat} :
+lemma revert_error_42b3090547df1d2001c96683413b8cf91c1b902ef5e3cb8d9f6f304cf7446f74_abs_of_code {s₀ s₉ : State}  {fuel : Nat} :
   execCall fuel revert_error_42b3090547df1d2001c96683413b8cf91c1b902ef5e3cb8d9f6f304cf7446f74 [] (s₀, []) = s₉ →
   Spec (A_revert_error_42b3090547df1d2001c96683413b8cf91c1b902ef5e3cb8d9f6f304cf7446f74  ) s₀ s₉
 := λ h ↦ revert_error_42b3090547df1d2001c96683413b8cf91c1b902ef5e3cb8d9f6f304cf7446f74_abs_of_concrete (revert_error_42b3090547df1d2001c96683413b8cf91c1b902ef5e3cb8d9f6f304cf7446f74_concrete_of_code.2 h)

--- a/Generated/erc20shim/ERC20Shim/revert_error_42b3090547df1d2001c96683413b8cf91c1b902ef5e3cb8d9f6f304cf7446f74_user.lean
+++ b/Generated/erc20shim/ERC20Shim/revert_error_42b3090547df1d2001c96683413b8cf91c1b902ef5e3cb8d9f6f304cf7446f74_user.lean
@@ -12,7 +12,7 @@ open Clear EVMState Ast Expr Stmt FunctionDefinition State Interpreter ExecLemma
 
 def A_revert_error_42b3090547df1d2001c96683413b8cf91c1b902ef5e3cb8d9f6f304cf7446f74   (s₀ s₉ : State) : Prop := sorry
 
-lemma revert_error_42b3090547df1d2001c96683413b8cf91c1b902ef5e3cb8d9f6f304cf7446f74_abs_of_concrete {s₀ s₉ : State}  } :
+lemma revert_error_42b3090547df1d2001c96683413b8cf91c1b902ef5e3cb8d9f6f304cf7446f74_abs_of_concrete {s₀ s₉ : State}  :
   Spec (revert_error_42b3090547df1d2001c96683413b8cf91c1b902ef5e3cb8d9f6f304cf7446f74_concrete_of_code.1  ) s₀ s₉ →
   Spec (A_revert_error_42b3090547df1d2001c96683413b8cf91c1b902ef5e3cb8d9f6f304cf7446f74  ) s₀ s₉ := by
   unfold revert_error_42b3090547df1d2001c96683413b8cf91c1b902ef5e3cb8d9f6f304cf7446f74_concrete_of_code A_revert_error_42b3090547df1d2001c96683413b8cf91c1b902ef5e3cb8d9f6f304cf7446f74

--- a/Generated/erc20shim/ERC20Shim/revert_error_ca66f745a3ce8ff40e2ccaf1ad45db7774001b90d25810abd9040049be7bf4bb.lean
+++ b/Generated/erc20shim/ERC20Shim/revert_error_ca66f745a3ce8ff40e2ccaf1ad45db7774001b90d25810abd9040049be7bf4bb.lean
@@ -12,7 +12,7 @@ section
 
 open Clear EVMState Ast Expr Stmt FunctionDefinition State Interpreter ExecLemmas OutOfFuelLemmas Abstraction YulNotation PrimOps ReasoningPrinciple Utilities 
 
-lemma revert_error_ca66f745a3ce8ff40e2ccaf1ad45db7774001b90d25810abd9040049be7bf4bb_abs_of_code {s₀ s₉ : State}  } {fuel : Nat} :
+lemma revert_error_ca66f745a3ce8ff40e2ccaf1ad45db7774001b90d25810abd9040049be7bf4bb_abs_of_code {s₀ s₉ : State}  {fuel : Nat} :
   execCall fuel revert_error_ca66f745a3ce8ff40e2ccaf1ad45db7774001b90d25810abd9040049be7bf4bb [] (s₀, []) = s₉ →
   Spec (A_revert_error_ca66f745a3ce8ff40e2ccaf1ad45db7774001b90d25810abd9040049be7bf4bb  ) s₀ s₉
 := λ h ↦ revert_error_ca66f745a3ce8ff40e2ccaf1ad45db7774001b90d25810abd9040049be7bf4bb_abs_of_concrete (revert_error_ca66f745a3ce8ff40e2ccaf1ad45db7774001b90d25810abd9040049be7bf4bb_concrete_of_code.2 h)

--- a/Generated/erc20shim/ERC20Shim/revert_error_ca66f745a3ce8ff40e2ccaf1ad45db7774001b90d25810abd9040049be7bf4bb_user.lean
+++ b/Generated/erc20shim/ERC20Shim/revert_error_ca66f745a3ce8ff40e2ccaf1ad45db7774001b90d25810abd9040049be7bf4bb_user.lean
@@ -12,7 +12,7 @@ open Clear EVMState Ast Expr Stmt FunctionDefinition State Interpreter ExecLemma
 
 def A_revert_error_ca66f745a3ce8ff40e2ccaf1ad45db7774001b90d25810abd9040049be7bf4bb   (s₀ s₉ : State) : Prop := sorry
 
-lemma revert_error_ca66f745a3ce8ff40e2ccaf1ad45db7774001b90d25810abd9040049be7bf4bb_abs_of_concrete {s₀ s₉ : State}  } :
+lemma revert_error_ca66f745a3ce8ff40e2ccaf1ad45db7774001b90d25810abd9040049be7bf4bb_abs_of_concrete {s₀ s₉ : State}  :
   Spec (revert_error_ca66f745a3ce8ff40e2ccaf1ad45db7774001b90d25810abd9040049be7bf4bb_concrete_of_code.1  ) s₀ s₉ →
   Spec (A_revert_error_ca66f745a3ce8ff40e2ccaf1ad45db7774001b90d25810abd9040049be7bf4bb  ) s₀ s₉ := by
   unfold revert_error_ca66f745a3ce8ff40e2ccaf1ad45db7774001b90d25810abd9040049be7bf4bb_concrete_of_code A_revert_error_ca66f745a3ce8ff40e2ccaf1ad45db7774001b90d25810abd9040049be7bf4bb

--- a/Generated/erc20shim/ERC20Shim/revert_error_dbdddcbe895c83990c08b3492a0e83918d802a52331272ac6fdb6a7c4aea3b1b.lean
+++ b/Generated/erc20shim/ERC20Shim/revert_error_dbdddcbe895c83990c08b3492a0e83918d802a52331272ac6fdb6a7c4aea3b1b.lean
@@ -12,7 +12,7 @@ section
 
 open Clear EVMState Ast Expr Stmt FunctionDefinition State Interpreter ExecLemmas OutOfFuelLemmas Abstraction YulNotation PrimOps ReasoningPrinciple Utilities 
 
-lemma revert_error_dbdddcbe895c83990c08b3492a0e83918d802a52331272ac6fdb6a7c4aea3b1b_abs_of_code {s₀ s₉ : State}  } {fuel : Nat} :
+lemma revert_error_dbdddcbe895c83990c08b3492a0e83918d802a52331272ac6fdb6a7c4aea3b1b_abs_of_code {s₀ s₉ : State}  {fuel : Nat} :
   execCall fuel revert_error_dbdddcbe895c83990c08b3492a0e83918d802a52331272ac6fdb6a7c4aea3b1b [] (s₀, []) = s₉ →
   Spec (A_revert_error_dbdddcbe895c83990c08b3492a0e83918d802a52331272ac6fdb6a7c4aea3b1b  ) s₀ s₉
 := λ h ↦ revert_error_dbdddcbe895c83990c08b3492a0e83918d802a52331272ac6fdb6a7c4aea3b1b_abs_of_concrete (revert_error_dbdddcbe895c83990c08b3492a0e83918d802a52331272ac6fdb6a7c4aea3b1b_concrete_of_code.2 h)

--- a/Generated/erc20shim/ERC20Shim/revert_error_dbdddcbe895c83990c08b3492a0e83918d802a52331272ac6fdb6a7c4aea3b1b_user.lean
+++ b/Generated/erc20shim/ERC20Shim/revert_error_dbdddcbe895c83990c08b3492a0e83918d802a52331272ac6fdb6a7c4aea3b1b_user.lean
@@ -12,7 +12,7 @@ open Clear EVMState Ast Expr Stmt FunctionDefinition State Interpreter ExecLemma
 
 def A_revert_error_dbdddcbe895c83990c08b3492a0e83918d802a52331272ac6fdb6a7c4aea3b1b   (s₀ s₉ : State) : Prop := sorry
 
-lemma revert_error_dbdddcbe895c83990c08b3492a0e83918d802a52331272ac6fdb6a7c4aea3b1b_abs_of_concrete {s₀ s₉ : State}  } :
+lemma revert_error_dbdddcbe895c83990c08b3492a0e83918d802a52331272ac6fdb6a7c4aea3b1b_abs_of_concrete {s₀ s₉ : State}  :
   Spec (revert_error_dbdddcbe895c83990c08b3492a0e83918d802a52331272ac6fdb6a7c4aea3b1b_concrete_of_code.1  ) s₀ s₉ →
   Spec (A_revert_error_dbdddcbe895c83990c08b3492a0e83918d802a52331272ac6fdb6a7c4aea3b1b  ) s₀ s₉ := by
   unfold revert_error_dbdddcbe895c83990c08b3492a0e83918d802a52331272ac6fdb6a7c4aea3b1b_concrete_of_code A_revert_error_dbdddcbe895c83990c08b3492a0e83918d802a52331272ac6fdb6a7c4aea3b1b

--- a/vc/src/Main.hs
+++ b/vc/src/Main.hs
@@ -259,7 +259,7 @@ fillInFunction topLevelContract file imports (FuncDef _ contract fargs ret body)
         funcArgs     = generateGuarded (null fargs) $ "(" ++ unwords fargs ++ " : Literal)"
         opens        = opensOfImports topLevelContract imports
         retVals      = generateGuarded (null ret) $ "(" ++ unwords ret ++ " : Identifier)"
-        rValsAndArgs = generateGuarded (null (ret ++ fargs)) "{" ++ unwords ret ++ " " ++ argsSepSpace ++ "}"
+        rValsAndArgs = generateGuarded (null (ret ++ fargs)) $ "{" ++ unwords ret ++ " " ++ argsSepSpace ++ "}"
         replaceIn ttype =
           replaceMany [
             ("\\<imports>",                       leanImports ++ internalImports topLevelContract contract file ttype),


### PR DESCRIPTION
See also: https://github.com/NethermindEth/Clear/pull/3.