### PR TITLE
Adding lemmas about EVM state and addresses

### DIFF
--- a/Clear/State.lean
+++ b/Clear/State.lean
@@ -633,6 +633,43 @@ lemma lookup_initcall_5 (ha : ve ≠ va) (hb : ve ≠ vb) (hc : ve ≠ vc) (hd :
   rw [lookup_insert']
   aesop
 
+@[simp]
+lemma get_evm_of_ok : (Ok evm store).evm = evm
+:= by
+  unfold evm
+  simp
+
+lemma get_evm_of_isOk (h : isOk s) : ∃ evm, s.evm = evm
+:= by
+  let ⟨evm, store, h'⟩ := State_of_isOk h
+  exists evm
+  rw [h']
+  simp
+
+@[simp]
+lemma evm_get_set_of_ok : ((Ok evm store).setEvm evm').evm = evm'
+:= by
+  unfold setEvm evm
+  simp
+
+@[simp]
+lemma evm_get_set_of_isOk (h : isOk s) : (s.setEvm evm').evm = evm'
+:= by
+  unfold setEvm evm
+  rcases s <;> simp <;> try contradiction
+
+@[simp]
+lemma setEvm_insert_comm : s⟦var ↦ val⟧.setEvm evm' = (s.setEvm evm')⟦var ↦ val⟧
+:= by
+  rcases s <;> [(try simp only); aesop_spec; aesop_spec]
+  rfl
+
+-- @[simp]
+lemma insert_setEvm_insert : (s.setEvm evm')⟦var ↦ val⟧ = s⟦var ↦ val⟧.setEvm evm'
+:= by
+  rcases s <;> [(try simp only); aesop_spec; aesop_spec]
+  rfl
+
 end
 
 end State

--- a/Clear/UInt256.lean
+++ b/Clear/UInt256.lean
@@ -11,7 +11,7 @@ import Mathlib.Tactic
 
 -- 2^256
 @[simp]
-def UInt256.size : ℕ := 115792089237316195423570985008687907853269984665640564039457584007913129639936
+def UInt256.size : ℕ := 2 ^ 256
 
 instance : NeZero UInt256.size := ⟨by decide⟩
 
@@ -26,6 +26,10 @@ instance : NatCast UInt256 := ⟨Fin.ofNat⟩
 
 abbrev Nat.toUInt256 : ℕ → UInt256 := Fin.ofNat
 abbrev UInt8.toUInt256 (a : UInt8) : UInt256 := a.toNat.toUInt256
+
+lemma UInt256.size_def
+  : UInt256.size = 115792089237316195423570985008687907853269984665640564039457584007913129639936 := by
+  unfold size; simp
 
 def Bool.toUInt256 (b : Bool) : UInt256 := if b then 1 else 0
 


### PR DESCRIPTION
@jkopanski asked me to make a series of pull requests bringing in work from the `erc20` branch that is applicable more generally. This one adds lemmas about the EVM state and addresses.

All except one of these pull requests should be able to be merged in any order.

I have tested that `lake build` succeeds.