### PR TITLE
Use GitHub Actions to check that building succeeds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,38 @@
+name: Build
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4.2.0
+      - name: The Determinate Nix Installer
+        uses: DeterminateSystems/nix-installer-action@v14
+      - name: Magic Nix Cache
+        uses: DeterminateSystems/magic-nix-cache-action@v8
+      - name: Cache Lean toolchain
+        uses: actions/cache@v4.1.0
+        with:
+          path: ~/.elan/toolchains
+          key: ${{ runner.os }}-lean-toolchain-${{ hashFiles('lean-toolchain') }}
+      - name: Cache Lean packages
+        id: cache-lean-packages
+        uses: actions/cache@v4.1.0
+        with:
+          path: .lake/packages
+          key: ${{ runner.os }}-lean-packages-${{ hashFiles('lake-manifest.json') }}
+      - if: ${{ steps.cache-lean-packages.outputs.cache-hit != 'true' }}
+        name: Get Mathlib cache
+        run: nix-shell --run "lake exe cache get"
+      - name: Build vc tool
+        run: nix-shell --run "cd vc; stack --nix build"
+      - name: Build Lean files
+        run: nix-shell --run "lake build"

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,7 @@
+{ pkgs ? import <nixpkgs> {} }:
+pkgs.mkShell {
+  packages = with pkgs; [ 
+    elan
+    stack
+  ];
+}


### PR DESCRIPTION
Hi, this adds a GitHub Action which runs `lake build` and `stack build`.
It will run automatically for pull requests to `main` or pushes to `main`.
It uses Nix to obtain the build inputs declared in `flake.nix` (currently `elan` and `stack`).
It caches the Lean toolchain and Lean packages (important especially since `mathlib` takes about 1 hour to build through GitHub Actions). It gets Mathlib using `lake exe cache get` if there is not GitHub Actions cache hit. [Note: I previously didn't realise getting Mathlib like this was possible, hence the new commit force-pushed].

The aim is to just check that `lake build` and `stack build` (in `vc`) are successful.

For this, it also adds a `flake.nix` with a `devShell` including `elan` and `stack`. The idea is to use `elan` to install `lean` rather than directly using Nix due to complications packaging `mathlib` in Nix such as discussed in https://github.com/leanprover/lean4/issues/5122 and keeping the setup instructions unchanged.

I've experimented with this in the `add-CI-2` branch of my fork.
This is the first run (7m58s): https://github.com/Coda-Coda/Nethermind-Clear/actions/runs/11208110827.
This is the next run (6m9s), after a minor test edit to `EVMState.lean` to test out rebuilding: https://github.com/Coda-Coda/Nethermind-Clear/actions/runs/11208261568.
The caching seems to be working as expected, giving a slightly faster build time.

I noticed that there was an old `blank.yml` file seemingly from a previous approach to using GitHub Actions: https://github.com/NethermindEth/Clear/blob/2ac080b162279dd99813c08ce937dab05cdea3a4/.github/workflows/blank.yml. It may be helpful to add aspects of that in, however this pull request takes a simpler approach. [Note: the `lake exe cache get` idea was taken from `blank.yml`].