### PR TITLE
Add `allowance` proof and tweak `balanceOf` proof, with updates to `Predicate.lean` and the helper functions

### DIFF
--- a/Generated/erc20shim/ERC20Shim/Predicate.lean
+++ b/Generated/erc20shim/ERC20Shim/Predicate.lean
@@ -61,7 +61,9 @@ structure IsERC20 (erc20 : ERC20) (s : State) : Prop where
   block_acc_range :
     ∀ {var},
     not_mem_private (s.evm.keccak_map.lookup [ var, ERC20Private.balances ]) ∧
-    not_mem_private (s.evm.keccak_map.lookup [ var, ERC20Private.allowances ])
+    not_mem_private (s.evm.keccak_map.lookup [ var, ERC20Private.allowances ]) ∧
+    (∀ var₂ intermediate, s.evm.keccak_map.lookup [ var, ERC20Private.allowances ] = some intermediate
+                    → not_mem_private (s.evm.keccak_map.lookup [ var₂, intermediate ]))
 
   -- block_allowance_range :
   --   ∀ {owner}, s.evm.keccak_map.lookup [ ↑owner, ERC20Private.allowances ] ∉ ERC20Private.toFinset

--- a/Generated/erc20shim/ERC20Shim/Predicate.lean
+++ b/Generated/erc20shim/ERC20Shim/Predicate.lean
@@ -41,7 +41,7 @@ structure IsERC20 (erc20 : ERC20) (s : State) : Prop where
     erc20.balances.lookup account = some (s.evm.sload address)
 
   hasAllowance :
-    ∀ {owner spender}, (⟨owner, spender⟩ ∈ erc20.allowances) →
+    ∀ {owner spender}, ((owner, spender) ∈ erc20.allowances) →
     ∃ (address  : UInt256) (intermediate : UInt256),
     s.evm.keccak_map.lookup [ ↑owner , ERC20Private.allowances ] = some intermediate ∧
     s.evm.keccak_map.lookup [ ↑spender , intermediate ] = some address ∧
@@ -53,7 +53,7 @@ structure IsERC20 (erc20 : ERC20) (s : State) : Prop where
         account ∈ erc20.balances ∧
         some address = s.evm.keccak_map.lookup [ ↑account, ERC20Private.balances ] }.toFinset ∪
       { address | ∃ owner spender,
-        ⟨owner, spender⟩ ∈ erc20.allowances ∧
+        (owner, spender) ∈ erc20.allowances ∧
         ∀ {intermediate}, s.evm.keccak_map.lookup [ ↑owner , ERC20Private.allowances ] = some intermediate →
         s.evm.keccak_map.lookup [ ↑spender , intermediate ] = some address }.toFinset ∪
       ERC20Private.toFinset

--- a/Generated/erc20shim/ERC20Shim/fun_allowance_user.lean
+++ b/Generated/erc20shim/ERC20Shim/fun_allowance_user.lean
@@ -27,28 +27,20 @@ lemma fun_allowance_abs_of_concrete {s₀ s₉ : State} {var var_owner var_spend
   rcases s₀ with ⟨evm, varstore⟩ | _ | _ <;> [simp only; aesop_spec; aesop_spec]
   apply spec_eq
   clr_funargs
-  intro hasFuel ⟨s, mapping, ⟨s', mapping', code⟩⟩ erc20 is_erc20
+  rintro hasFuel ⟨s, mapping, ⟨s', mapping', code⟩⟩ erc20 is_erc20
 
   clr_varstore
 
   -- what we can get right now from mapping function
-  unfold A_mapping_index_access_mapping_address_mapping_address_uint256_of_address at mapping
-  unfold A_mapping_index_access_mapping_address_uint256_of_address at mapping
+  unfold A_mapping_index_access_mapping_address_mapping_address_uint256_of_address
+         A_mapping_index_access_mapping_address_uint256_of_address at mapping
   clr_spec at mapping
   obtain ⟨preservesEvm, s_isOk, ⟨intermediate_keccak, keccak_using_intermediate, hStore⟩⟩ := mapping
   obtain ⟨evmₛ, varstoreₛ, s_eq_ok⟩ := State_of_isOk s_isOk
   have keccak : Finmap.lookup [↑↑(Address.ofUInt256 var_owner), 1] s.evm.keccak_map = some (s["_2"]!!) := by
-    rw [s_eq_ok]
-    rw [s_eq_ok] at hStore
-    unfold store at hStore
-    simp at hStore
-    unfold State.insert at hStore
-    simp at hStore
-    conv_lhs => rw[←s_eq_ok]
-    rw [hStore]
+    unfold store State.insert at hStore
     unfold lookup!
-    simp
-    exact keccak_using_intermediate
+    aesop
 
   rw [ ← Variables.allowances_def
      , s_eq_ok, get_evm_of_ok, ← s_eq_ok
@@ -93,16 +85,8 @@ lemma fun_allowance_abs_of_concrete {s₀ s₉ : State} {var var_owner var_spend
   -- make use of transitivity of Preserved
   have hPreserved'' : Clear.Preserved evm evmₛ' := Preserved.trans hPreserved hPreserved'
 
-  apply And.intro
-  -- IsERC20 for the final state
-  exact IsERC20_of_preservesEvm (by aesop) is_erc20
-
+  refine' ⟨IsERC20_of_preservesEvm (by aesop) is_erc20, (by aesop), ?returns_correct_value⟩
   rw [← code]
-  apply And.intro
-  -- preservesEvm s₀ s₉
-  rw [ preservesEvm_of_insert' ]
-  exact preservesEvm_of_preserved _ _ hPreserved''
-
   -- lookup allowance
   clr_varstore
   by_cases mem : ⟨Address.ofUInt256 var_owner, Address.ofUInt256 var_spender⟩ ∈ erc20.allowances

--- a/Generated/erc20shim/ERC20Shim/fun_allowance_user.lean
+++ b/Generated/erc20shim/ERC20Shim/fun_allowance_user.lean
@@ -228,7 +228,12 @@ lemma fun_allowance_abs_of_concrete {s₀ s₉ : State} {var var_owner var_spend
       have := keccak_map_lookup_eq_of_Preserved_of_lookup hPreserved'' spender_lookup'
       rw [this] at hSpender
 
-      have keccak_inj := evmₛ'.keccak_inj (by sorry) (Eq.symm hSpender)
+      have : [↑↑(Address.ofUInt256 (s["var_spender"]!!)), s["_2"]!!] ∈ evmₛ'.keccak_map.keys := by
+        clear * -keccak_using_intermediate' s_eq_ok'
+        rw [s_eq_ok'] at keccak_using_intermediate'
+        simp at keccak_using_intermediate'
+        exact Finmap.mem_of_lookup_eq_some keccak_using_intermediate'
+      have keccak_inj := evmₛ'.keccak_inj this (Eq.symm hSpender)
       rw [← Fin.ofNat''_eq_cast, ← Fin.ofNat''_eq_cast] at keccak_inj
       unfold Fin.ofNat'' at keccak_inj
       simp at keccak_inj
@@ -236,7 +241,6 @@ lemma fun_allowance_abs_of_concrete {s₀ s₉ : State} {var var_owner var_spend
 
       obtain ⟨keccak_inj₁, keccak_inj₂⟩ := keccak_inj
 
-      have hMemOwner := Finmap.mem_of_lookup_eq_some keccak
 
       have hOwner : owner = Address.ofUInt256 var_owner := by
         have := keccak_map_lookup_eq_of_Preserved_of_lookup hPreserved owner_lookup
@@ -245,7 +249,12 @@ lemma fun_allowance_abs_of_concrete {s₀ s₉ : State} {var var_owner var_spend
         have owner_lookup'' := get_evm_of_ok ▸ owner_lookup
         rw [this] at owner_lookup''
 
-        have keccak_inj := evmₛ.keccak_inj (by sorry) (Eq.symm owner_lookup'')
+        have : [↑↑(Address.ofUInt256 var_owner), ERC20Private.allowances] ∈ evmₛ.keccak_map.keys := by
+          clear * -keccak_using_intermediate s_eq_ok
+          rw [s_eq_ok] at keccak_using_intermediate
+          simp at keccak_using_intermediate
+          exact Finmap.mem_of_lookup_eq_some keccak_using_intermediate
+        have keccak_inj := evmₛ.keccak_inj this (Eq.symm owner_lookup'')
         rw [← Fin.ofNat''_eq_cast, ← Fin.ofNat''_eq_cast] at keccak_inj
         unfold Fin.ofNat'' at keccak_inj
         simp at keccak_inj

--- a/Generated/erc20shim/ERC20Shim/fun_allowance_user.lean
+++ b/Generated/erc20shim/ERC20Shim/fun_allowance_user.lean
@@ -149,11 +149,17 @@ lemma fun_allowance_abs_of_concrete {s₀ s₉ : State} {var var_owner var_spend
       unfold Fin.ofNat'' at keccak_inj
       simp at keccak_inj
       obtain ⟨keccak_inj₁, keccak_inj₂⟩ := keccak_inj
-      rw [Nat.mod_eq_of_lt, Nat.mod_eq_of_lt, Fin.val_eq_val] at keccak_inj₁
-      · rw [keccak_inj₁] at account_mem_balances
-        exact (mem account_mem_balances)
-      · exact Address.ofUInt256_lt_UInt256_size
-      · exact Address.val_lt_UInt256_size
+
+      have : ERC20Private.balances ≠ s["_2"]!! := by
+        obtain blocked_range := get_evm_of_ok ▸ s_erc20.block_acc_range.2
+        rw [ keccak ] at blocked_range
+        apply not_mem_private_of_some at blocked_range
+        rw [@ne_comm]
+        unfold PrivateAddresses.toFinset at blocked_range
+        rw [Finset.mem_def] at blocked_range
+        simp at blocked_range
+        exact blocked_range.1
+      contradiction
 
     -- address not in allowances
     · intro owner spender mem_allowances
@@ -194,8 +200,8 @@ lemma fun_allowance_abs_of_concrete {s₀ s₉ : State} {var var_owner var_spend
       tauto
 
     -- address not in reserved space
-    · obtain blocked_range := get_evm_of_ok ▸ s_erc20.block_acc_range.1
-      rw [ keccak ] at blocked_range
+    · obtain blocked_range := get_evm_of_ok ▸ s_erc20'.block_acc_range.2
+      rw [ keccak' ] at blocked_range
       apply not_mem_private_of_some at blocked_range
       exact blocked_range
 

--- a/Generated/erc20shim/ERC20Shim/fun_allowance_user.lean
+++ b/Generated/erc20shim/ERC20Shim/fun_allowance_user.lean
@@ -1,10 +1,8 @@
 import Clear.ReasoningPrinciple
 
-import Generated.erc20shim.ERC20Shim.mapping_index_access_mapping_address_mapping_address_uint256_of_address
-import Generated.erc20shim.ERC20Shim.mapping_index_access_mapping_address_uint256_of_address
-
 import Generated.erc20shim.ERC20Shim.fun_allowance_gen
 
+import Generated.erc20shim.ERC20Shim.Predicate
 
 namespace Generated.erc20shim.ERC20Shim
 
@@ -12,13 +10,192 @@ section
 
 open Clear EVMState Ast Expr Stmt FunctionDefinition State Interpreter ExecLemmas OutOfFuelLemmas Abstraction YulNotation PrimOps ReasoningPrinciple Utilities Generated.erc20shim ERC20Shim
 
-def A_fun_allowance (var : Identifier) (var_owner var_spender : Literal) (s₀ s₉ : State) : Prop := sorry
+def A_fun_allowance (var : Identifier) (var_owner var_spender : Literal) (s₀ s₉ : State) : Prop :=
+  ∀ {erc20}, IsERC20 erc20 s₀ →
+  let owner := Address.ofUInt256 var_owner
+  let spender := Address.ofUInt256 var_spender
+  IsERC20 erc20 s₉ ∧ preservesEvm s₀ s₉ ∧
+  s₉[var]!! = (erc20.allowances.lookup ⟨owner, spender⟩).getD 0
 
 lemma fun_allowance_abs_of_concrete {s₀ s₉ : State} {var var_owner var_spender} :
   Spec (fun_allowance_concrete_of_code.1 var var_owner var_spender) s₀ s₉ →
   Spec (A_fun_allowance var var_owner var_spender) s₀ s₉ := by
   unfold fun_allowance_concrete_of_code A_fun_allowance
-  sorry
+
+  rcases s₀ with ⟨evm, varstore⟩ | _ | _ <;> [simp only; aesop_spec; aesop_spec]
+  apply spec_eq
+  clr_funargs
+  intro hasFuel ⟨s, mapping, ⟨s', mapping', code⟩⟩ erc20 is_erc20
+
+  clr_varstore
+
+  -- what we can get right now from mapping function
+  unfold A_mapping_index_access_mapping_address_mapping_address_uint256_of_address at mapping
+  unfold A_mapping_index_access_mapping_address_uint256_of_address at mapping
+  clr_spec at mapping
+  obtain ⟨preservesEvm, s_isOk, keccak⟩ := mapping
+  obtain ⟨evmₛ, varstoreₛ, s_eq_ok⟩ := State_of_isOk s_isOk
+  rw [ ← Variables.allowances_def
+     , s_eq_ok, get_evm_of_ok, ← s_eq_ok
+     ] at keccak
+
+  -- what we can get right now from mapping' function
+  unfold A_mapping_index_access_mapping_address_uint256_of_address at mapping'
+  clr_spec at mapping'
+  obtain ⟨preservesEvm', s_isOk', keccak'⟩ := mapping'
+  obtain ⟨evmₛ', varstoreₛ', s_eq_ok'⟩ := State_of_isOk s_isOk'
+  rw [ s_eq_ok', get_evm_of_ok, ← s_eq_ok'
+     ] at keccak'
+
+  -- simplify contract
+  unfold reviveJump at code
+  simp [s_eq_ok, s_eq_ok'] at code
+  rw [ ← State.insert_of_ok,  ← State.insert_of_ok, ← s_eq_ok' ] at code
+  clr_varstore
+
+  -- get underlying Preserved from preservesEvm
+  rw [ s_eq_ok, preservesEvm_of_insert, preservesEvm_of_insert ] at preservesEvm
+  have hPreserved := Preserved_of_preservesEvm_of_Ok preservesEvm
+
+  -- get underlying Preserved from preservesEvm'
+  rw [ s_eq_ok, s_eq_ok'] at preservesEvm'
+  have hPreserved' := Preserved_of_preservesEvm_of_Ok preservesEvm'
+
+  -- make use of transitivity of Preserved
+  have hPreserved'' : Clear.Preserved evm evmₛ' := Preserved.trans hPreserved hPreserved'
+
+  apply And.intro
+  -- IsERC20 for the final state
+  exact IsERC20_of_preservesEvm (by aesop) is_erc20
+
+  rw [← code]
+  apply And.intro
+  -- preservesEvm s₀ s₉
+  rw [ preservesEvm_of_insert' ]
+  exact preservesEvm_of_preserved _ _ hPreserved''
+
+  -- lookup balance
+  clr_varstore
+  by_cases mem : ⟨Address.ofUInt256 var_owner, Address.ofUInt256 var_spender⟩ ∈ erc20.allowances
+  -- there is such ⟨owner, spender⟩ in allowances
+  obtain ⟨address, intermediate, has_intermediate, has_address, balance⟩ := is_erc20.hasAllowance mem
+
+  have intermediate_def : s["_2"]!! = intermediate := by
+    rw [s_eq_ok]
+    rw [← Option.some_inj]
+    trans
+    · have := Eq.symm (s_eq_ok ▸ keccak)
+      exact this
+    · exact (keccak_map_lookup_eq_of_Preserved_of_lookup hPreserved has_intermediate
+        ▸ has_intermediate)
+
+  have address_def : s'["_3"]!! = address := by
+    rw [s_eq_ok']
+    rw [← Option.some_inj]
+    trans
+    · have := Eq.symm (s_eq_ok' ▸ keccak')
+      exact this
+    · rw [intermediate_def]
+      have : s["var_spender"]!! = var_spender := by sorry
+      rw [this]
+      exact (keccak_map_lookup_eq_of_Preserved_of_lookup hPreserved'' has_address ▸ has_address)
+
+  -- up to here
+
+  rw [address_def] at code ⊢
+  rw [ balance
+     , Option.getD_some
+     , State.get_evm_of_ok
+     , ← sload_eq_of_preserved hPreserved''
+     ]
+
+  -- there is *no* such account in balances
+  -- so sload should return 0
+  rw [ Finmap.lookup_eq_none.mpr mem
+     , Option.getD_none
+     ]
+
+  -- in order to do that it should be given storage address outside of
+  -- it's domain
+  apply sload_of_not_mem_dom
+  have := State.get_evm_of_ok ▸ is_erc20.storageDom
+  rw [ ← storage_eq_of_preserved hPreserved''
+     , this
+     ]
+  clear this
+  simp only [ Finset.not_mem_union, Set.mem_toFinset, Set.mem_def, setOf, not_exists, not_and ]
+  have s_erc20 : IsERC20 erc20 (Ok evmₛ _) :=
+    IsERC20_of_ok_of_Preserved hPreserved is_erc20
+
+  split_ands
+  -- address not in balances
+  · intro account account_mem_balances
+    obtain ⟨address, has_address, balance⟩ := is_erc20.hasBalance account_mem_balances
+    rw [ ← keccak'
+       , keccak_map_lookup_eq_of_Preserved_of_lookup
+           hPreserved has_address ]
+    by_contra h
+    have : [↑↑account, ERC20Private.balances] ∈ evmₛ.keccak_map.keys := by
+      rw [Finmap.mem_keys]
+      apply Finmap.lookup_isSome.mp
+      have := get_evm_of_ok ▸ has_address
+      rw [ ← keccak_map_lookup_eq_of_Preserved_of_lookup hPreserved has_address
+         , this ]
+      simp
+    have keccak_inj := evmₛ.keccak_inj this (Eq.symm h)
+
+    rw [← Fin.ofNat''_eq_cast, ← Fin.ofNat''_eq_cast] at keccak_inj
+    unfold Fin.ofNat'' at keccak_inj
+    simp at keccak_inj
+    rw [Nat.mod_eq_of_lt, Nat.mod_eq_of_lt, Fin.val_eq_val] at keccak_inj
+    rw [keccak_inj] at account_mem_balances
+    exact (mem account_mem_balances)
+    · exact Address.ofUInt256_lt_UInt256_size
+    · exact Address.val_lt_UInt256_size
+
+  -- address not in allowances
+  · intro owner spender mem_allowances
+    obtain ⟨erc_address, erc_intermediate, owner_lookup, spender_lookup, eq⟩ :=
+      is_erc20.hasAllowance mem_allowances
+    rw [get_evm_of_ok] at owner_lookup spender_lookup
+    have spender_lookup_s := keccak_map_lookup_eq_of_Preserved_of_lookup Preserved spender_lookup
+    push_neg
+    use erc_intermediate
+    rw [ ← keccak ]
+    by_contra h
+    rw [not_and'] at h
+    apply h at owner_lookup
+    exact owner_lookup
+
+    rw [spender_lookup_s]
+    by_contra h
+    have : [spender, erc_intermediate] ∈ evmₛ.keccak_map.keys := by
+      rw [Finmap.mem_keys]
+      apply Finmap.lookup_isSome.mp
+      have := Eq.trans (Eq.symm spender_lookup_s) spender_lookup
+      rw [this]
+      simp
+    have keccak_inj := evmₛ.keccak_inj this h
+    simp at keccak_inj
+    have intermediate_ne_balances : erc_intermediate ≠ ERC20Private.balances := by
+      obtain blocked_range := get_evm_of_ok ▸ is_erc20.block_acc_range.2
+      rw [owner_lookup] at blocked_range
+      unfold not_mem_private at blocked_range
+      simp at blocked_range
+      rw [← Finset.forall_mem_not_eq] at blocked_range
+      have bal_mem_private: ERC20Private.balances ∈ ERC20Private.toFinset := by
+        unfold PrivateAddresses.toFinset
+        simp
+      specialize blocked_range ERC20Private.balances
+      exact blocked_range bal_mem_private
+
+    tauto
+
+  -- address not in reserved space
+  · obtain blocked_range := get_evm_of_ok ▸ s_erc20.block_acc_range.1
+    rw [ keccak ] at blocked_range
+    apply not_mem_private_of_some at blocked_range
+    exact blocked_range
 
 end
 

--- a/Generated/erc20shim/ERC20Shim/fun_balanceOf_user.lean
+++ b/Generated/erc20shim/ERC20Shim/fun_balanceOf_user.lean
@@ -32,8 +32,14 @@ lemma fun_balanceOf_abs_of_concrete {s₀ s₉ : State} {var var_account} :
   -- what we can get right now from mapping function
   unfold A_mapping_index_access_mapping_address_uint256_of_address at mapping
   clr_spec at mapping
-  obtain ⟨preservesEvm, s_isOk, keccak⟩ := mapping  
+  obtain ⟨preservesEvm, s_isOk, ⟨keccak_value, keccak_using_keccak_value, hStore⟩⟩ := mapping
   obtain ⟨evmₛ, varstoreₛ, s_eq_ok⟩ := State_of_isOk s_isOk
+
+  have keccak : Finmap.lookup [↑↑(Address.ofUInt256 var_account), 0] s.evm.keccak_map = some (s["_2"]!!) := by
+    unfold store State.insert at hStore
+    unfold lookup!
+    aesop
+
   rw [ ← Variables.balances_def
      , s_eq_ok, get_evm_of_ok, ← s_eq_ok
      ] at keccak
@@ -148,7 +154,7 @@ lemma fun_balanceOf_abs_of_concrete {s₀ s₉ : State} {var var_account} :
     have keccak_inj := evmₛ.keccak_inj this h
     simp at keccak_inj
     have intermediate_ne_balances : erc_intermediate ≠ ERC20Private.balances := by
-      obtain blocked_range := get_evm_of_ok ▸ is_erc20.block_acc_range.2
+      obtain blocked_range := get_evm_of_ok ▸ is_erc20.block_acc_range.2.1
       rw [owner_lookup] at blocked_range
       unfold not_mem_private at blocked_range
       simp at blocked_range

--- a/Generated/erc20shim/ERC20Shim/fun_balanceOf_user.lean
+++ b/Generated/erc20shim/ERC20Shim/fun_balanceOf_user.lean
@@ -139,7 +139,7 @@ lemma fun_balanceOf_abs_of_concrete {s₀ s₉ : State} {var var_account} :
 
     rw [spender_lookup_s]
     by_contra h
-    have : [spender, erc_intermediate] ∈ evmₛ.keccak_map.keys := by
+    have : [↑↑spender, erc_intermediate] ∈ evmₛ.keccak_map.keys := by
       rw [Finmap.mem_keys]
       apply Finmap.lookup_isSome.mp
       have := Eq.trans (Eq.symm spender_lookup_s) spender_lookup

--- a/Generated/erc20shim/ERC20Shim/fun_balanceOf_user.lean
+++ b/Generated/erc20shim/ERC20Shim/fun_balanceOf_user.lean
@@ -25,7 +25,7 @@ lemma fun_balanceOf_abs_of_concrete {s₀ s₉ : State} {var var_account} :
   rcases s₀ with ⟨evm, varstore⟩ | _ | _ <;> [simp only; aesop_spec; aesop_spec]
   apply spec_eq
   clr_funargs
-  intro hasFuel ⟨s, mapping, code⟩ erc20 is_erc20
+  rintro hasFuel ⟨s, mapping, code⟩ erc20 is_erc20
 
   clr_varstore
 
@@ -54,16 +54,9 @@ lemma fun_balanceOf_abs_of_concrete {s₀ s₉ : State} {var var_account} :
   rw [ s_eq_ok, preservesEvm_of_insert, preservesEvm_of_insert ] at preservesEvm
   have Preserved := Preserved_of_preservesEvm_of_Ok preservesEvm
 
-  apply And.intro
-  -- IsERC20 for the final state
-  exact IsERC20_of_preservesEvm (by aesop) is_erc20
+  refine' ⟨IsERC20_of_preservesEvm (by aesop) is_erc20, (by aesop), ?returns_correct_value⟩
 
   rw [← code]
-  apply And.intro
-  -- preservesEvm s₀ s₉
-  rw [ preservesEvm_of_insert' ]
-  exact preservesEvm_of_preserved _ _ Preserved
-
   -- lookup balance
   clr_varstore
   by_cases mem : Address.ofUInt256 var_account ∈ erc20.balances

--- a/Generated/erc20shim/ERC20Shim/mapping_index_access_mapping_address_mapping_address_uint256_of_address_user.lean
+++ b/Generated/erc20shim/ERC20Shim/mapping_index_access_mapping_address_mapping_address_uint256_of_address_user.lean
@@ -17,7 +17,7 @@ lemma mapping_index_access_mapping_address_mapping_address_uint256_of_address_ab
   Spec (mapping_index_access_mapping_address_mapping_address_uint256_of_address_concrete_of_code.1 dataSlot slot key) s₀ s₉ →
   Spec (A_mapping_index_access_mapping_address_mapping_address_uint256_of_address dataSlot slot key) s₀ s₉ := by
   unfold mapping_index_access_mapping_address_mapping_address_uint256_of_address_concrete_of_code A_mapping_index_access_mapping_address_mapping_address_uint256_of_address
-  unfold A_mapping_index_access_mapping_address_uint256_of_address
+         A_mapping_index_access_mapping_address_uint256_of_address
 
   rcases s₀ with ⟨evm, varstore⟩ | _ | _ <;> [simp only; aesop_spec; aesop_spec]
   apply spec_eq

--- a/Generated/erc20shim/ERC20Shim/mapping_index_access_mapping_address_mapping_address_uint256_of_address_user.lean
+++ b/Generated/erc20shim/ERC20Shim/mapping_index_access_mapping_address_mapping_address_uint256_of_address_user.lean
@@ -2,21 +2,29 @@ import Clear.ReasoningPrinciple
 
 
 import Generated.erc20shim.ERC20Shim.mapping_index_access_mapping_address_mapping_address_uint256_of_address_gen
-
+import Generated.erc20shim.ERC20Shim.mapping_index_access_mapping_address_uint256_of_address_user
 
 namespace Generated.erc20shim.ERC20Shim
 
 section
 
-open Clear EVMState Ast Expr Stmt FunctionDefinition State Interpreter ExecLemmas OutOfFuelLemmas Abstraction YulNotation PrimOps ReasoningPrinciple Utilities 
+open Clear EVMState Ast Expr Stmt FunctionDefinition State Interpreter ExecLemmas OutOfFuelLemmas Abstraction YulNotation PrimOps ReasoningPrinciple Utilities
 
-def A_mapping_index_access_mapping_address_mapping_address_uint256_of_address (dataSlot : Identifier) (slot key : Literal) (s₀ s₉ : State) : Prop := sorry
+def A_mapping_index_access_mapping_address_mapping_address_uint256_of_address (dataSlot : Identifier) (slot key : Literal) (s₀ s₉ : State) : Prop :=
+  A_mapping_index_access_mapping_address_uint256_of_address dataSlot slot key s₀ s₉
 
 lemma mapping_index_access_mapping_address_mapping_address_uint256_of_address_abs_of_concrete {s₀ s₉ : State} {dataSlot slot key} :
   Spec (mapping_index_access_mapping_address_mapping_address_uint256_of_address_concrete_of_code.1 dataSlot slot key) s₀ s₉ →
   Spec (A_mapping_index_access_mapping_address_mapping_address_uint256_of_address dataSlot slot key) s₀ s₉ := by
   unfold mapping_index_access_mapping_address_mapping_address_uint256_of_address_concrete_of_code A_mapping_index_access_mapping_address_mapping_address_uint256_of_address
+  unfold A_mapping_index_access_mapping_address_uint256_of_address
+
+  rcases s₀ with ⟨evm, varstore⟩ | _ | _ <;> [simp only; aesop_spec; aesop_spec]
+  apply spec_eq
+  intro hasFuel
+  clr_funargs
   sorry
+
 
 end
 

--- a/Generated/erc20shim/ERC20Shim/mapping_index_access_mapping_address_uint256_of_address_user.lean
+++ b/Generated/erc20shim/ERC20Shim/mapping_index_access_mapping_address_uint256_of_address_user.lean
@@ -18,8 +18,9 @@ set_option linter.setOption false
 set_option pp.coercions false
 
 def A_mapping_index_access_mapping_address_uint256_of_address (dataSlot : Identifier) (slot key : Literal) (s₀ s₉ : State) : Prop :=
-  preservesEvm s₀ s₉ ∧ s₉.isOk ∧
-  s₉.evm.keccak_map.lookup [ ↑(Address.ofUInt256 key), slot ] = some (s₉[dataSlot]!!)
+  preservesEvm s₀ s₉ ∧ s₉.isOk ∧ (∃ keccak,
+  s₉.evm.keccak_map.lookup [ ↑(Address.ofUInt256 key), slot ] = some keccak ∧
+  s₉.store = s₀⟦dataSlot ↦ keccak⟧.store)
 
 -- Helper reifications
 lemma shift_eq_size : Fin.shiftLeft (n := UInt256.size) 1 160 = Address.size := by


### PR DESCRIPTION
@jkopanski, this pull request (to the `erc20` branch) includes the finished `allowance` proof (based on your `balanceOf` proof) as well as tweaks to the `balanceOf` proof related to the changes that seemed necessary to `Predicate.lean` and the two helper functions:
- `mapping_index_access_mapping_address_uint256_of_address`
- `mapping_index_access_mapping_address_mapping_address_uint256_of_address`

Both `lake build +Generated.erc20shim.ERC20Shim.fun_balanceOf_user` and `lake build +Generated.erc20shim.ERC20Shim.fun_allowance_user` succeed.

Also there are some minor proof style related changes.