### PR TITLE
Fix default value for `hash_collision` in EVMState

### DIFF
--- a/Clear/EVMState.lean
+++ b/Clear/EVMState.lean
@@ -162,7 +162,7 @@ structure EVMState : Type where
 deriving DecidableEq
 
 instance : Inhabited EVMState :=
-  ⟨ ∅ , default, default , ∅ , default, ∅ , default , False ⟩
+  ⟨ ∅ , default, default , ∅ , default, ∅ , default , false ⟩
 
 abbrev EVM := EVMState
 


### PR DESCRIPTION
This fixes the default value for `hash_collision` as defined in `EVMState.lean`

`false` is a `Bool`. The intended default value.
`False` is the `Prop` representing a contradiction, not the intended default value of `hash_collision`, but since `False` is a decidable proposition, Lean automatically treats this as `decide False` which is a `Bool`. Although we can actually prove `false = False` in Lean, using `false` directly is preferable.

The way this is handled in Lean leads to the following:
`theorem false_eq_false  : false = false := by rfl  -- succeeds (of course)`
`theorem false_eq_False₁ : false = False := by rfl  -- fails`
`theorem false_eq_False₂ : false = False := by simp -- succeeds`

This has implications when doing proofs relating to the default value for `hash_collision`, such as here: https://github.com/NethermindEth/Clear/blob/4bd6a340ba7b8484405cdfacaa6bda2add8394db/Generated/erc20shim/ERC20Shim/fun_allowance_user.lean#L400 (currently in the branch [WIP-erc20-daniel-3](https://github.com/NethermindEth/Clear/blob/WIP-erc20-daniel-3/Generated/erc20shim/ERC20Shim/fun_allowance_user.lean#L400)). Changing the default value for `hash_collision` back to `False` there causes `lake build +Generated.erc20shim.ERC20Shim.fun_allowance_user` to fail. We could work around this in the proof, but it seems better to fix `EVMState.lean` instead.