### PR TITLE
Make use of the keccak helper proof for the other keccak helper

### DIFF
--- a/Generated/erc20shim/ERC20Shim/mapping_index_access_mapping_address_mapping_address_uint256_of_address_user.lean
+++ b/Generated/erc20shim/ERC20Shim/mapping_index_access_mapping_address_mapping_address_uint256_of_address_user.lean
@@ -17,14 +17,7 @@ lemma mapping_index_access_mapping_address_mapping_address_uint256_of_address_ab
   Spec (mapping_index_access_mapping_address_mapping_address_uint256_of_address_concrete_of_code.1 dataSlot slot key) s₀ s₉ →
   Spec (A_mapping_index_access_mapping_address_mapping_address_uint256_of_address dataSlot slot key) s₀ s₉ := by
   unfold mapping_index_access_mapping_address_mapping_address_uint256_of_address_concrete_of_code A_mapping_index_access_mapping_address_mapping_address_uint256_of_address
-         A_mapping_index_access_mapping_address_uint256_of_address
-
-  rcases s₀ with ⟨evm, varstore⟩ | _ | _ <;> [simp only; aesop_spec; aesop_spec]
-  apply spec_eq
-  intro hasFuel
-  clr_funargs
-  sorry
-
+  apply mapping_index_access_mapping_address_uint256_of_address_abs_of_concrete
 
 end
 


### PR DESCRIPTION
This completes the proof of `mapping_index_access_mapping_address_mapping_address_uint256_of_address_abs_of_concrete` by making use of the `mapping_index_access_mapping_address_uint256_of_address_abs_of_concrete` proof (no need for copy/paste).